### PR TITLE
Some tweaks

### DIFF
--- a/php/index.php
+++ b/php/index.php
@@ -56,7 +56,7 @@ function isEmpty($var) {
     return !isset($var) || strlen(trim($var)) == 0;
 }
 
-function sendEmailForReportAsFilenameForSender($path, $filename, $userEmail = '') {
+function sendEmailForReportAsFilenameForSender($path, $filename, $app, $userEmail = '') {
     $mail = new PHPMailer(true);
 
     //Server settings
@@ -83,9 +83,11 @@ function sendEmailForReportAsFilenameForSender($path, $filename, $userEmail = ''
     $mail->addAttachment($path, $filename);
 
     // Content
-    $mail->Subject = 'Crash log ' . $filename;
-    $message = 'Crash log processed on ' . date("Y-m-d H:i:s") . "<br>\r\n"
-      . 'Sender: ' . (!isEmpty($userEmail) ? $userEmail : '(unknown)') . "<br>\r\n<br>\r\n";
+    $mail->Subject = $app . ' crash log' . (!isEmpty($userEmail) ? ' from ' . $userEmail : '');
+    
+    $message = 'Processed on: ' . date("Y-m-d H:i:s") . "<br>\r\n"
+      . 'App: ' . $app . "<br>\r\n"
+      . 'Sender: ' . (!isEmpty($userEmail) ? $userEmail : 'unknown') . "<br>\r\n<br>\r\n";
     $mail->Body    = $message;
     $mail->AltBody = $message;
 
@@ -118,7 +120,7 @@ try {
     fseek($tmpfile, 0);
     $path = stream_get_meta_data($tmpfile)['uri'];
 
-    sendEmailForReportAsFilenameForSender($path, $filename, $userEmail);
+    sendEmailForReportAsFilenameForSender($path, $filename, $app, $userEmail);
 } catch (Exception $e) { // PHPMailer exception
     header('X-PHP-Response-Code: 400', true, 400);
     echo($e->getMessage());


### PR DESCRIPTION
This PR changes three things:
- Crash report files now choose their extension based on the report format (pre-Monterey reports get a `.crash` extensions, and Monterey-and-up JSON reports get a `.ips` extension). This can help with reading and symbolicating the report files.
- Dates in crash report files are now more legible (from `20240124185539` to `2024-01-24 18.55.39`)
- Email subject and body have been reworked. The subject now shows the app name, and reporter email if any. The body is now formatted as a uniform list, and includes the app name.

I've bundled these changes as a single PR for simplicity, but as some of these are quite subjective, I understand if you want to only keep some of them, of course.


| Current  | PR |
| ------------- | ------------- |
|  ![2024-01-24 19 55 Screenshot](https://github.com/CleanCocoa/CrashReporter/assets/2979318/79efabfa-4984-4b97-b8ab-1b9a0277a5c4) | ![Untitled](https://github.com/CleanCocoa/CrashReporter/assets/2979318/3996c4d7-7255-4576-bc7c-5fd7e8fee49d) |

