### PR TITLE
Fix using through SwiftPM

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 
 //  Copyright © 2019 Christian Tietze. All rights reserved. Distributed under the MIT License.
 

--- a/Sources/CrashReporter/CrashReporterBundle.swift
+++ b/Sources/CrashReporter/CrashReporterBundle.swift
@@ -1,0 +1,16 @@
+//
+//  CrashReporterBundle.swift
+//  CrashReporter
+//
+//  Created by Nathan Manceaux-Panot on 2024-11-16.
+//
+
+import Foundation
+
+let CrashReporterBundle: Bundle = {
+#if SWIFT_PACKAGE
+	return Bundle.module
+#else
+	return Bundle.main
+#endif
+}()

--- a/Sources/CrashReporter/UI/CrashReportWindowController.swift
+++ b/Sources/CrashReporter/UI/CrashReportWindowController.swift
@@ -19,14 +19,21 @@ final class CrashReportWindowController: NSWindowController, NSWindowDelegate {
         privacyPolicyURL: URL,
         collectEmailSetting: EmailAddressSetting,
         sendReportsAutomaticallySetting: SendReportsAutomaticallySetting) {
+		self.init()
 
-        self.init(windowNibName: "CrashReporterWindow")
+		var nibTopLevelObjects: NSArray?
+		CrashReporterBundle.loadNibNamed("CrashReporterWindow", owner: self, topLevelObjects: &nibTopLevelObjects)
+		self.window = nibTopLevelObjects?.lazy.compactMap({ $0 as? NSWindow }).first
 
         self.crashLogText = crashLogText
         self.crashLogSender = crashLogSender
         self.privacyPolicyURL = privacyPolicyURL
         self.collectEmailSetting = collectEmailSetting
         self.sendReportsAutomaticallySetting = sendReportsAutomaticallySetting
+		
+		// Replicate default init behavior
+		window?.delegate = self
+		windowDidLoad()
     }
 
     override func windowDidLoad() {

--- a/Sources/CrashReporter/UI/CrashReportWindowController.swift
+++ b/Sources/CrashReporter/UI/CrashReportWindowController.swift
@@ -31,13 +31,7 @@ final class CrashReportWindowController: NSWindowController, NSWindowDelegate {
         self.collectEmailSetting = collectEmailSetting
         self.sendReportsAutomaticallySetting = sendReportsAutomaticallySetting
 		
-		// Replicate default init behavior
-		window?.delegate = self
-		windowDidLoad()
-    }
-
-    override func windowDidLoad() {
-        super.windowDidLoad()
+		// Setup window
         window?.center()
         window?.delegate = self
 

--- a/Sources/CrashReporter/UI/CrashReportWindowController.swift
+++ b/Sources/CrashReporter/UI/CrashReportWindowController.swift
@@ -18,20 +18,22 @@ final class CrashReportWindowController: NSWindowController, NSWindowDelegate {
         crashLogSender: SendsCrashLog,
         privacyPolicyURL: URL,
         collectEmailSetting: EmailAddressSetting,
-        sendReportsAutomaticallySetting: SendReportsAutomaticallySetting) {
-		self.init()
+        sendReportsAutomaticallySetting: SendReportsAutomaticallySetting
+    ) {
+        self.init()
 
-		var nibTopLevelObjects: NSArray?
-		CrashReporterBundle.loadNibNamed("CrashReporterWindow", owner: self, topLevelObjects: &nibTopLevelObjects)
-		self.window = nibTopLevelObjects?.lazy.compactMap({ $0 as? NSWindow }).first
+        var nibTopLevelObjects: NSArray?
+        CrashReporterBundle.loadNibNamed(
+            "CrashReporterWindow", owner: self, topLevelObjects: &nibTopLevelObjects)
+        self.window = nibTopLevelObjects?.lazy.compactMap({ $0 as? NSWindow }).first
 
         self.crashLogText = crashLogText
         self.crashLogSender = crashLogSender
         self.privacyPolicyURL = privacyPolicyURL
         self.collectEmailSetting = collectEmailSetting
         self.sendReportsAutomaticallySetting = sendReportsAutomaticallySetting
-		
-		// Setup window
+
+        // Setup window
         window?.center()
         window?.delegate = self
 
@@ -49,13 +51,13 @@ final class CrashReportWindowController: NSWindowController, NSWindowDelegate {
 
     // MARK: View components
 
-	@IBOutlet var textView: NSTextView! {
-		didSet {
-			textView.font = NSFont.userFixedPitchFont(ofSize: 0.0)
-			textView.textContainerInset = NSSize(width: 5.0, height: 5.0)
-			updateCrashLogText()
-		}
-	}
+    @IBOutlet var textView: NSTextView! {
+        didSet {
+            textView.font = NSFont.userFixedPitchFont(ofSize: 0.0)
+            textView.textContainerInset = NSSize(width: 5.0, height: 5.0)
+            updateCrashLogText()
+        }
+    }
 
     @IBOutlet weak var collectEmailContainerView: NSView!
     @IBOutlet weak var emailAddressTitleLabel: NSTextField!
@@ -94,8 +96,8 @@ final class CrashReportWindowController: NSWindowController, NSWindowDelegate {
         return constraint
     }()
 
-	@IBOutlet var sendCrashLogButton: NSButton!
-	@IBOutlet var dontSendButton: NSButton!
+    @IBOutlet var sendCrashLogButton: NSButton!
+    @IBOutlet var dontSendButton: NSButton!
 
     private func updateCrashLogText() {
         guard let textView = self.textView else { return }
@@ -130,7 +132,8 @@ final class CrashReportWindowController: NSWindowController, NSWindowDelegate {
         sendAutomaticallyLabel?.isHidden = isDisabled
 
         if isDisabled {
-            if !sendAutomaticallyContainerView.constraints.contains(hideSendAutomaticallyConstraint) {
+            if !sendAutomaticallyContainerView.constraints.contains(hideSendAutomaticallyConstraint)
+            {
                 sendAutomaticallyContainerView.addConstraint(hideSendAutomaticallyConstraint)
             }
         } else {
@@ -194,34 +197,35 @@ final class CrashReportWindowController: NSWindowController, NSWindowDelegate {
         }
     }
 
-	private var didSendCrashLog = false {
-		didSet {
-			updateButtonStates()
-		}
-	}
+    private var didSendCrashLog = false {
+        didSet {
+            updateButtonStates()
+        }
+    }
 
-	// MARK: - User Interactions
+    // MARK: - User Interactions
 
     lazy var isRunningTests: Bool = false
 
-	@IBAction func sendCrashReport(_ sender: Any?) {
-		guard !didSendCrashLog else { return }
+    @IBAction func sendCrashReport(_ sender: Any?) {
+        guard !didSendCrashLog else { return }
         defer { didSendCrashLog = true }
 
-		if  !isRunningTests,
+        if !isRunningTests,
             let crashLogText = self.crashLogText,
-            let crashLogSender = self.crashLogSender {
+            let crashLogSender = self.crashLogSender
+        {
 
             let emailAddress = self.collectEmailSetting.isVisible ? self.emailAddress : nil
             crashLogSender.send(emailAddress: emailAddress, crashLogText: crashLogText)
-		}
+        }
 
-		close()
-	}
+        close()
+    }
 
-	@IBAction func dontSendCrashReport(_ sender: Any?) {
-		close()
-	}
+    @IBAction func dontSendCrashReport(_ sender: Any?) {
+        close()
+    }
 
     override func responds(to aSelector: Selector!) -> Bool {
         if aSelector == #selector(showPrivacyPolicy(_:)) {
@@ -235,4 +239,3 @@ final class CrashReportWindowController: NSWindowController, NSWindowDelegate {
         NSWorkspace.shared.open(privacyPolicyURL)
     }
 }
-

--- a/Sources/CrashReporter/UI/CrashReporterWindow.xib
+++ b/Sources/CrashReporter/UI/CrashReporterWindow.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -26,12 +27,12 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="251" y="776" width="496" height="646"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="3440" height="1415"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2304" height="1271"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="496" height="646"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="QBv-7S-WQv">
+                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="QBv-7S-WQv">
                         <rect key="frame" x="18" y="607" width="460" height="19"/>
                         <textFieldCell key="cell" selectable="YES" title="New Crash Log Found" id="k6r-PA-hYf">
                             <font key="font" metaFont="systemBold" size="16"/>
@@ -39,7 +40,7 @@
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="b7P-9Z-RkD">
+                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="b7P-9Z-RkD">
                         <rect key="frame" x="18" y="567" width="460" height="32"/>
                         <textFieldCell key="cell" selectable="YES" id="O6E-xl-G55">
                             <font key="font" metaFont="system"/>
@@ -78,7 +79,7 @@
                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="eP6-Ir-fFJ" userLabel="Email Container View" customClass="NoClippingView" customModule="CrashReporter" customModuleProvider="target">
                         <rect key="frame" x="20" y="132" width="456" height="105"/>
                         <subviews>
-                            <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3xM-Nb-4hh">
+                            <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3xM-Nb-4hh">
                                 <rect key="frame" x="0.0" y="20" width="456" height="21"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Email Address (optional)" drawsBackground="YES" usesSingleLineMode="YES" id="HjN-Q4-rQR">
                                     <font key="font" usesAppearanceFont="YES"/>
@@ -94,7 +95,7 @@
                                     </binding>
                                 </connections>
                             </textField>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dOk-kx-oBq">
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dOk-kx-oBq">
                                 <rect key="frame" x="-2" y="89" width="180" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Optional Contact Information" id="h6e-ob-y0Q">
                                     <font key="font" metaFont="system"/>
@@ -102,7 +103,7 @@
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Xnj-T5-Udi">
+                            <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Xnj-T5-Udi">
                                 <rect key="frame" x="-2" y="49" width="460" height="32"/>
                                 <textFieldCell key="cell" selectable="YES" title="To get back to you and help with a fix for the problem, please provide your email address." id="Nur-Qq-JDS">
                                     <font key="font" metaFont="system"/>
@@ -142,7 +143,7 @@
                                     </binding>
                                 </connections>
                             </button>
-                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="D5D-Vb-5TR">
+                            <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="D5D-Vb-5TR">
                                 <rect key="frame" x="-2" y="20" width="460" height="48"/>
                                 <textFieldCell key="cell" allowsUndo="NO" id="nou-5k-c1U">
                                     <font key="font" metaFont="system"/>

--- a/Sources/CrashReporter/UI/CrashReporterWindow.xib
+++ b/Sources/CrashReporter/UI/CrashReporterWindow.xib
@@ -6,7 +6,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <customObject id="-2" userLabel="File's Owner" customClass="CrashReportWindowController" customModule="CrashReporter" customModuleProvider="target">
+        <customObject id="-2" userLabel="File's Owner" customClass="CrashReportWindowController" customModule="CrashReporter">
             <connections>
                 <outlet property="collectEmailContainerView" destination="eP6-Ir-fFJ" id="aAL-v4-DPA"/>
                 <outlet property="dontSendButton" destination="o4V-7L-v6D" id="Sxa-iT-OTj"/>
@@ -76,7 +76,7 @@
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                     </scrollView>
-                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="eP6-Ir-fFJ" userLabel="Email Container View" customClass="NoClippingView" customModule="CrashReporter" customModuleProvider="target">
+                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="eP6-Ir-fFJ" userLabel="Email Container View" customClass="NoClippingView" customModule="CrashReporter">
                         <rect key="frame" x="20" y="132" width="456" height="105"/>
                         <subviews>
                             <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3xM-Nb-4hh">
@@ -125,7 +125,7 @@
                             <constraint firstItem="Xnj-T5-Udi" firstAttribute="top" secondItem="dOk-kx-oBq" secondAttribute="bottom" constant="8" id="z6O-hW-3vU"/>
                         </constraints>
                     </customView>
-                    <customView horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="7JX-Ab-aSd" customClass="NoClippingView" customModule="CrashReporter" customModuleProvider="target">
+                    <customView horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="7JX-Ab-aSd" customClass="NoClippingView" customModule="CrashReporter">
                         <rect key="frame" x="20" y="40" width="456" height="92"/>
                         <subviews>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="MDs-Wi-EiJ">
@@ -163,7 +163,7 @@
                             <constraint firstItem="MDs-Wi-EiJ" firstAttribute="top" secondItem="7JX-Ab-aSd" secondAttribute="top" id="z9F-2V-CvJ"/>
                         </constraints>
                     </customView>
-                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="pgd-B4-8yx" userLabel="Actions Container View" customClass="NoClippingView" customModule="CrashReporter" customModuleProvider="target">
+                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="pgd-B4-8yx" userLabel="Actions Container View" customClass="NoClippingView" customModule="CrashReporter">
                         <rect key="frame" x="20" y="20" width="456" height="20"/>
                         <subviews>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fEy-Fg-JhO">


### PR DESCRIPTION
The CrashReportWindowController wouldn't find its nib when CrashReporter was loaded through SwiftPM.

- Bump package tools version (see: https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package)
- Disable module auto discovery in nib
- Change window controller initialization code to manually load the nib
	- Add CrashReporterBundle to expose correct current bundle
